### PR TITLE
fix package name for beautifulsoup4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ if __name__ == '__main__':
         platforms=['Any'],
         install_requires=[
             'requests',
-            'beautifulsoup',
+            'beautifulsoup4',
             'mf2py',
             'html5lib',
             'lxml',


### PR DESCRIPTION
setup.py contains dependency on `beautifulsoup`, which is Beautiful Soup 3 and not compatible with Python 3, breaking pip/setup.py install. Code actually requires Beautiful Soup 4, which is in package `beautifulsoup4`. 

(I assume everything worked on Python 2, since mf2py pulls in beautifulsoup4 additionally, so that both versions are installed)

EDIT: So Python3 doesn't seem to work anyways out of the box, so this "just" fixes an unnecessary dependency