### PR TITLE
add use_2to3=True to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ if __name__ == '__main__':
         license=extract_metaitem('license'),
         packages=find_packages(exclude=('tests', 'docs')),
         platforms=['Any'],
+        use_2to3=True,
         install_requires=[
             'requests',
             'beautifulsoup4',


### PR DESCRIPTION
From what I can tell, ronkyuu works fine if simply converted using 2to3. This PR enables it in setup.py so that `pip install ronkyuu` should also work with python3.

Tests have to be converted manually with 2to3, I don't fully understand how nosetests works with setup.py and didn't manage to get it to work automatically.